### PR TITLE
Fix python_requires

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix python_requires
+  [cillianderoiste]
 
 
 1.0b1 (2020-07-28)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
+    python_requires=">=2.7",
     install_requires=[
         "setuptools",
         # -*- Extra requirements: -*-


### PR DESCRIPTION
Previously this was "==2.7, >=3.6", but the "," ands the two
conditions (https://www.python.org/dev/peps/pep-0440/#version-specifiers),
so no version can be both ==2.7 and >=3.6.

For me it failed with:
ERROR: Package 'collective-easyformplugin-fields' requires a different
Python: 3.8.0 not in '==2.7,>=3.6'