### PR TITLE
Don't reassign the widgets on Choice and Set fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Don't reassign the widgets on Choice and Set fields in IEasyFormForm's in view.py. [fredvd]
 
 
 1.0 (2021-08-10)

--- a/src/collective/easyformplugin/fields/view.py
+++ b/src/collective/easyformplugin/fields/view.py
@@ -21,10 +21,6 @@ class SimpleFormForm(EasyFormForm):
                 field.widgetFactory["input"] = ParameterizedWidget(ConsentFieldWidget)
             elif isinstance(field.field, Divider):
                 field.widgetFactory["input"] = ParameterizedWidget(DividerFieldWidget)
-            elif isinstance(field.field, Choice):
-                field.widgetFactory["input"] = ParameterizedWidget(RadioFieldWidget)
-            elif isinstance(field.field, Set):
-                field.widgetFactory["input"] = ParameterizedWidget(CheckBoxWidget)
         super(SimpleFormForm, self).updateWidgets()
 
 


### PR DESCRIPTION
 in IEasyFormForm's in view.py.

This creates strange widget fixations on normal forms when you install this add'on as well.